### PR TITLE
fix: Add SSL_HOSTNAME support for remote SSL connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,22 @@ By default, when you deploy Postgres from the offical Postgres template on PipeO
 
 The Dockerfiles contained in this repository start with the official Postgres image as base.  Then the `init-ssl.sh` script is copied into the `docker-entrypoint-initdb.d/` directory to be executed upon initialization.
 
-#### Cert expiry
-By default, the cert expiry is set to 820 days.  You can control this by configuring the `SSL_CERT_DAYS` environment variable as needed.
+### Environment Variables
+
+#### SSL_CERT_DAYS
+By default, the cert expiry is set to 820 days. You can control this by configuring the `SSL_CERT_DAYS` environment variable as needed.
+
+#### SSL_HOSTNAME
+By default, the SSL certificate is generated with `localhost` as the Common Name (CN) and Subject Alternative Name (SAN). This works for local connections but causes SSL verification failures when connecting remotely via a proxy or custom domain.
+
+Set `SSL_HOSTNAME` to your public hostname (e.g., `mydb.example.com`) to include it in the certificate's SAN. The certificate will always include `localhost`, `0.0.0.0`, and `127.0.0.1` as valid SANs regardless of this setting.
+
+**Example:**
+```bash
+SSL_HOSTNAME=mydb.pipeops.app
+```
+
+This allows `sslmode=require` connections to work properly when connecting via the specified hostname.
 
 ### A note about ports
 


### PR DESCRIPTION
## Problem

The SSL certificate was generated with only `localhost` as the Subject Alternative Name (SAN), causing SSL verification failures when connecting via proxy or custom domain with `sslmode=require`.

**Error when connecting remotely:**
```
SSL connection error: certificate verify failed
```

## Solution

- Add `SSL_HOSTNAME` env var to specify custom hostname for certificate CN/SAN
- Include `IP:0.0.0.0` and `IP:127.0.0.1` in SAN for IP-based connections  
- Always include `DNS:localhost` for local connections
- Update README with `SSL_HOSTNAME` documentation

## Usage

Set the `SSL_HOSTNAME` environment variable to your public hostname:

```bash
SSL_HOSTNAME=mydb.pipeops.app
```

This allows `sslmode=require` to work when connecting via public hostnames.

## Testing

1. Deploy with `SSL_HOSTNAME` set to your public domain
2. Connect with `sslmode=require` - should succeed
3. Connect via localhost - should still work