### PR TITLE
fix: use $PGDATA for SSL certificate directory

### DIFF
--- a/wrapper.sh
+++ b/wrapper.sh
@@ -10,7 +10,8 @@ if [ -z "$PGDATA" ]; then
 fi
 
 # Set up needed variables
-SSL_DIR="/var/lib/postgresql/data/certs"
+# Use $PGDATA to support custom data directory paths (e.g., /var/lib/postgresql/data/pgdata)
+SSL_DIR="$PGDATA/certs"
 INIT_SSL_SCRIPT="/docker-entrypoint-initdb.d/init-ssl.sh"
 POSTGRES_CONF_FILE="$PGDATA/postgresql.conf"
 


### PR DESCRIPTION
## Problem

The SSL_DIR was hardcoded to `/var/lib/postgresql/data/certs` which breaks when PGDATA is set to a subdirectory (e.g., `/var/lib/postgresql/data/pgdata`).

This caused SSL certificates to not be generated for existing databases because the `wrapper.sh` check was looking in the wrong directory:

```bash
# wrapper.sh was checking:
SSL_DIR="/var/lib/postgresql/data/certs"  # Wrong!

# But PGDATA was:
/var/lib/postgresql/data/pgdata
```

### Symptoms
- PostgreSQL logs show: `PostgreSQL Database directory appears to contain a database; Skipping initialization`
- No SSL-related logs appear
- `sslmode=require` connections fail with: `server does not support SSL, but SSL was required`
- SSL certs directory doesn't exist

## Solution

Changed both `init-ssl.sh` and `wrapper.sh` to use `$PGDATA/certs` instead of the hardcoded path.

## Changes
- `init-ssl.sh`: Use `$PGDATA/certs` instead of hardcoded path
- `wrapper.sh`: Use `$PGDATA/certs` instead of hardcoded path

## Testing

After this fix:
1. Fresh databases will have SSL enabled via `init-ssl.sh`
2. Existing databases (migrated from non-SSL image) will have SSL enabled via `wrapper.sh` on next restart