### PR TITLE
Fix/ssl pgdata path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
 FROM postgres:16.10
 
-# Install OpenSSL and sudo
-RUN apt-get update && apt-get install -y openssl sudo
-
-# Allow the postgres user to execute certain commands as root without a password
-RUN echo "postgres ALL=(root) NOPASSWD: /usr/bin/mkdir, /bin/chown, /usr/bin/openssl" > /etc/sudoers.d/postgres
+# Install OpenSSL for SSL certificate generation
+RUN apt-get update && apt-get install -y --no-install-recommends openssl \
+    && rm -rf /var/lib/apt/lists/*
 
 # Add init scripts while setting permissions
 COPY --chmod=755 init-ssl.sh /docker-entrypoint-initdb.d/init-ssl.sh


### PR DESCRIPTION
This pull request simplifies the SSL certificate initialization process for the PostgreSQL Docker image by removing unnecessary use of `sudo` and user ownership changes, making the setup more streamlined and secure. The changes also ensure that only the required packages are installed and that the Docker image remains clean.

**Dockerfile improvements:**

* Removed installation of `sudo` and related configuration for the `postgres` user, since elevated permissions are no longer required during initialization. Now only `openssl` is installed, and package lists are cleaned up to reduce image size.

**SSL initialization script (`init-ssl.sh`) simplification:**

* Eliminated all uses of `sudo` and direct `chown` commands, since the `postgres` user already owns the relevant directories and files. Directory creation and file operations now occur directly, simplifying the script and reducing potential permission issues. [[1]](diffhunk://#diff-481e6a7e951897ecd0eb6f42f1dab8faad0b5b6f5f980c660b65b249bf98c2d3L21-R22) [[2]](diffhunk://#diff-481e6a7e951897ecd0eb6f42f1dab8faad0b5b6f5f980c660b65b249bf98c2d3L42-L43) [[3]](diffhunk://#diff-481e6a7e951897ecd0eb6f42f1dab8faad0b5b6f5f980c660b65b249bf98c2d3L63-R66)
* Added a confirmation message at the end of the script to indicate successful SSL certificate generation.